### PR TITLE
Fixed absolute paths for input files

### DIFF
--- a/cube2sphere/cube2sphere.py
+++ b/cube2sphere/cube2sphere.py
@@ -48,7 +48,7 @@ def main():
     faces = [_args.front, _args.back, _args.right, _args.left, _args.top, _args.bottom]
     for i in range(len(faces)):
         face = faces[i]
-        face = faces if os.path.isabs(face) else os.path.join(os.getcwd(), face)
+        face = faces[i] if os.path.isabs(face) else os.path.join(os.getcwd(), face)
         faces[i] = face
 
     try:


### PR DESCRIPTION
Hi,

Here's a mini-fix: supplying cube2sphere with absolute paths fails (with a `TypeError: execv() arg 2 must contain only strings` message). That's because the whole list of faces is set to the filename instead of just the current faces path.
